### PR TITLE
Increase output to match recipe maximums

### DIFF
--- a/src/main/java/com/oierbravo/createsifter/content/contraptions/components/sifter/SifterTileEntity.java
+++ b/src/main/java/com/oierbravo/createsifter/content/contraptions/components/sifter/SifterTileEntity.java
@@ -47,7 +47,7 @@ public class SifterTileEntity extends KineticTileEntity {
         super(type, pos, state);
 
         inputInv = new ItemStackHandler(1);
-        outputInv = new ItemStackHandler(9);
+        outputInv = new ItemStackHandler(16);
         capability = LazyOptional.of(SifterInventoryHandler::new);
         meshInv = new ItemStackHandler(1){
             @Override


### PR DESCRIPTION
Sifting recipes allow a maximum of 16 outputs but the internal inventory of the sifter only allows for 9 outputs which voids all other outputs. This is a simple PR to adjust the internal inventory to 16 to match the possible max sifter outputs