### PR TITLE
Fix contents duplicating during psychic assemble (sable/aeronautics)

### DIFF
--- a/src/main/java/com/oierbravo/createsifter/content/contraptions/components/sifter/AbstractSifterBlock.java
+++ b/src/main/java/com/oierbravo/createsifter/content/contraptions/components/sifter/AbstractSifterBlock.java
@@ -159,7 +159,7 @@ public abstract class AbstractSifterBlock<BE extends BlockEntity> extends Kineti
 
     @Override
     public void onRemove(BlockState state, Level worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (state.hasBlockEntity() && state.getBlock() != newState.getBlock()) {
+        if (!isMoving && state.hasBlockEntity() && state.getBlock() != newState.getBlock()) {
             withBlockEntityDo(worldIn, pos, be -> {
                 AbstractSifterBlockEntity sifter = (AbstractSifterBlockEntity) be;
                 ItemHelper.dropContents(worldIn, pos, sifter.getInputInventory());


### PR DESCRIPTION
When blocks are moved via psychic assemble, onRemove is triggered and the contents are dropped/duplicated. Added a !pIsMoving check to prevent dropping items.